### PR TITLE
New Fields and Formats

### DIFF
--- a/src/Fieldset.php
+++ b/src/Fieldset.php
@@ -173,20 +173,21 @@ class Fieldset extends Registry
             if (in_array(
                 $field['field']['type'],
                 [
-                        'filelist',
-                        'imagelist',
-                        'tag',
-                        'textlist',
-                        'textarealist',
-                        'wysiwyglist',
-                        'meta',
-                        'checkboxes',
-                        'multirange',
-                        'rawjson',
-                        'multiselect',
-                        'fieldset',
-                        'table'
-                    ]
+                    'filelist',
+                    'imagelist',
+                    'tag',
+                    'textlist',
+                    'textarealist',
+                    'wysiwyglist',
+                    'meta',
+                    'checkboxes',
+                    'multirange',
+                    'rawjson',
+                    'multiselect',
+                    'fieldset',
+                    'table',
+                    'latlng'
+                ]
             )
             ) {
                 $results[] = $name;

--- a/src/Fieldset/events.php
+++ b/src/Fieldset/events.php
@@ -183,7 +183,7 @@ $this->on('system-fieldset-remove', function ($request, $response) {
         rename($path, $new);
     }
 
-    $response->setError(false)->setResults($results);
+    $response->setError(false)->setResults($data);
 });
 
 /**
@@ -222,7 +222,7 @@ $this->on('system-fieldset-restore', function ($request, $response) {
         rename($path, $new);
     }
 
-    $response->setError(false)->setResults($results);
+    $response->setError(false)->setResults($data);
 });
 
 /**

--- a/src/Fieldset/template/_scripts.html
+++ b/src/Fieldset/template/_scripts.html
@@ -67,21 +67,6 @@
                 $(this).attr('data-name', name);
             });
 
-            $('input', copy).each(function() {
-                var value = $(this).val();
-                $(this).attr('value', value);
-            });
-
-            $('input', copy).each(function() {
-                var value = $(this).val();
-                $(this).attr('value', value);
-            });
-
-            $('textarea', copy).each(function() {
-                var value = $(this).val();
-                $(this).html(value);
-            });
-
             $('#modal-template')
                 .compile({INDEX: index})
                 .find('div.modal-body')
@@ -587,6 +572,8 @@
                     .removeClass('modal-create')
                     .addClass('modal-update')
                 );
+
+            $('h5.modal-title', modal).html('Edit Field');
         }
 
         var row = $(trigger).parents('tr.fieldset-field-row').eq(0);
@@ -1098,7 +1085,49 @@
 
     //----------------------------//
     // Functions
+    var $clone = $.fn.clone;
     $.fn.extend({
+        clone: function() {
+            //before cloning we need to set the html states for fields
+            //considerations
+            // input
+            // - checkbox
+            // - radio
+            // textarea
+            // select
+            $('input', this).each(function() {
+                $(this).attr('value', $(this).val());
+
+                var type = ($(this).attr('type') || 'text').toLowerCase();
+
+                if (type === 'radio' || type === 'checkbox') {
+                    var checked = $(this).prop('checked');
+                    if (checked) {
+                        $(this).attr('checked', 'checked');
+                    } else {
+                        $(this).removeAttr('checked');
+                    }
+                }
+            });
+
+            $('textarea', this).each(function() {
+                $(this).html($(this).val());
+            });
+
+            $('select', this).each(function() {
+                var selected = this.options[this.selectedIndex];
+                $('option', this).removeAttr('selected');
+
+                if (selected) {
+                    $(selected).attr('selected', 'selected');
+                }
+            });
+
+            var withDataAndEvents = arguments[0] || false;
+            var deepWithDataAndEvents = arguments[1] || false;
+            var clone = $clone.call(this, withDataAndEvents, deepWithDataAndEvents);
+            return clone;
+        },
         compile: function(variables) {
             var template = this.text();
 

--- a/src/Fieldset/template/_scripts.html
+++ b/src/Fieldset/template/_scripts.html
@@ -491,8 +491,6 @@
 
             row.doon();
         });
-
-        $(target).formlog()
     });
 
     $(window).on('modal-cancel-click', function(e, trigger) {
@@ -516,8 +514,6 @@
 
     $(window).on('modal-save-click', function(e, trigger) {
         var modal = $(trigger).parents('div.modal').eq(0);
-
-        $(modal).formlog()
 
         $('.is-error', modal).removeClass('is-error');
         $('div.error-message', modal).remove();

--- a/src/Fieldset/template/options/_format.html
+++ b/src/Fieldset/template/options/_format.html
@@ -185,6 +185,15 @@
         Table
     </option>
     <option
+        data-fieldset="text"
+        data-placeholder-1="Width"
+        data-placeholder-2="Height"
+        value="carousel"
+        {{#when format '===' 'carousel'}}selected{{/when}}
+    >
+        Image Carousel
+    </option>
+    <option
         value="jsonpretty"
         {{#when format '===' 'jsonpretty'}}selected{{/when}}
     >

--- a/src/Fieldset/template/options/_type.html
+++ b/src/Fieldset/template/options/_type.html
@@ -243,6 +243,14 @@
     >
         Radios Fieldset
     </option>
+    <option
+        data-fieldset="attributes"
+        data-format="string"
+        value="countrylist"
+        {{#when field.type '===' 'countrylist'}}selected{{/when}}
+    >
+        Country List Field
+    </option>
 </optgroup>
 <optgroup label="File Fields">
     <option

--- a/src/Fieldset/template/options/_type.html
+++ b/src/Fieldset/template/options/_type.html
@@ -290,24 +290,24 @@
     <option
         data-fieldset="attributes"
         data-format="json"
-        value="texts"
-        {{#when field.type '===' 'texts'}}selected{{/when}}
+        value="textlist"
+        {{#when field.type '===' 'textlist'}}selected{{/when}}
     >
         Text List Fieldset
     </option>
     <option
         data-fieldset="attributes"
         data-format="json"
-        value="textareas"
-        {{#when field.type '===' 'textareas'}}selected{{/when}}
+        value="textarealist"
+        {{#when field.type '===' 'textarealist'}}selected{{/when}}
     >
         Textarea List Fieldset
     </option>
     <option
         data-fieldset="attributes"
         data-format="json"
-        value="wysiwygs"
-        {{#when field.type '===' 'wysiwygs'}}selected{{/when}}
+        value="wysiwyglist"
+        {{#when field.type '===' 'wysiwyglist'}}selected{{/when}}
     >
         WYSIWYG List Fieldset
     </option>

--- a/src/Fieldset/template/options/_type.html
+++ b/src/Fieldset/template/options/_type.html
@@ -344,6 +344,14 @@
         Multi Range Field
     </option>
     <option
+        data-fieldset="attributes"
+        data-format="json"
+        value="latlng"
+        {{#when field.type '===' 'latlng'}}selected{{/when}}
+    >
+        Lat/Lng
+    </option>
+    <option
         data-fieldset="attributes|fieldset"
         data-format="json"
         value="fieldset"

--- a/src/Model/Formatter.php
+++ b/src/Model/Formatter.php
@@ -69,6 +69,19 @@ class Formatter
                 $data[$name] = date('Y-m-d H:i:s');
             }
 
+            if ($field['field']['type'] === 'latlng' && is_array($data[$name])) {
+                if (!is_numeric($data[$name][0])) {
+                    $data[$name][0] = 0;
+                }
+
+                if (!is_numeric($data[$name][1])) {
+                    $data[$name][1] = 0;
+                }
+
+                $data[$name][0] = sprintf('%.8F', $data[$name][0]);
+                $data[$name][1] = sprintf('%.8F', $data[$name][1]);
+            }
+
             if ($field['field']['type'] === 'fieldset') {
                 //case for multiple
                 if (isset($field['field']['attributes']['data-multiple'])
@@ -118,6 +131,7 @@ class Formatter
                 case 'multirange':
                 case 'multiselect':
                 case 'table':
+                case 'latlng':
                 case 'fieldset':
                     //if it's an array already
                     if((is_array($data[$name]) || is_object($data[$name])) && is_null($fieldset)) {
@@ -237,7 +251,8 @@ class Formatter
                         'multirange',
                         'rawjson',
                         'fieldset',
-                        'table'
+                        'table',
+                        'latlng'
                     ]
                 )
             ) {

--- a/src/Model/Formatter.php
+++ b/src/Model/Formatter.php
@@ -184,7 +184,8 @@ class Formatter
                 case 'token':
                     $data[$name] = md5(uniqid());
                     break;
-                case 'number' || 'small':
+                case 'number':
+                case 'small':
                     if (!$data[$name]) {
                         $data[$name] = null;
                     }

--- a/src/Model/Formatter.php
+++ b/src/Model/Formatter.php
@@ -188,6 +188,13 @@ class Formatter
                     if (!$data[$name]) {
                         $data[$name] = null;
                     }
+                    break;
+                case 'textarea':
+                case 'wysiwyg':
+                case 'code':
+                    //fix for textarea in textarea
+                    $data[$name] = str_replace('<\/textarea>', '</textarea>', $data[$name]);
+                    break;
             }
         }
 

--- a/src/Model/Service/SqlService.php
+++ b/src/Model/Service/SqlService.php
@@ -64,6 +64,7 @@ class SqlService
         $table = $this->schema->getName();
         $created = $this->schema->getCreatedFieldName();
         $updated = $this->schema->getUpdatedFieldName();
+        $ipaddress = $this->schema->getIPAddressFieldName();
 
         if ($created) {
             $data[$created] = date('Y-m-d H:i:s');
@@ -71,6 +72,10 @@ class SqlService
 
         if ($updated) {
             $data[$updated] = date('Y-m-d H:i:s');
+        }
+
+        if ($ipaddress && isset($_SERVER['REMOTE_ADDR'])) {
+            $data[$ipaddress] = $_SERVER['REMOTE_ADDR'];
         }
 
         $uuids = $this->schema->getUuidFieldNames();

--- a/src/Model/Service/SqlService.php
+++ b/src/Model/Service/SqlService.php
@@ -463,7 +463,10 @@ class SqlService
             $search->setRange($range);
         }
 
-        // get json fields
+        // collect searchable
+        $searchable = $this->schema->getSearchableFieldNames();
+
+        // collect json fields
         $fields = $this->schema->getJsonFieldNames();
 
         //consider forward relations
@@ -485,6 +488,9 @@ class SqlService
                         $relation['name'],
                         $relation['primary2']
                     );
+
+                //add to searchable
+                $searchable = array_merge($searchable, $relation['searchable']);
             //needs to have a filter to add the other kinds of joins
             } else if (!isset($filter[$relation['primary2']])
                 && !isset($in[$relation['primary2']])
@@ -679,8 +685,6 @@ class SqlService
         }
 
         //keyword?
-        $searchable = $this->schema->getSearchableFieldNames();
-
         if (!empty($searchable)) {
             $keywords = [];
 

--- a/src/Model/template/form.html
+++ b/src/Model/template/form.html
@@ -23,7 +23,7 @@
             </li>
         {{else}}
             <li class="breadcrumb-item">
-                <a 
+                <a
                     {{#when action '===' 'create'}}
                         href="search"
                     {{else}}
@@ -110,7 +110,11 @@
                             data-target-value="input.suggestion-value-{{name}}"
                             {{#in ../valid_relations name}}
                                 {{#when ../action '===' 'create'}}
-                                    data-url="../{{name}}/search?q={QUERY}&render=false"
+                                    {{#if ../relation.suggestion}}
+                                        data-url="../../../{{name}}/search?q={QUERY}&render=false"
+                                    {{else}}
+                                        data-url="../{{name}}/search?q={QUERY}&render=false"
+                                    {{/if}}
                                 {{else}}
                                     data-url="../../{{name}}/search?q={QUERY}&render=false"
                                 {{/when}}

--- a/src/Model/template/format/detail.html
+++ b/src/Model/template/format/detail.html
@@ -73,15 +73,17 @@
     <a href="{{compile config.parameters.0 row}}">{{compile config.parameters.1 row}}</a>
 {{/when}}
 {{#when config.format '===' 'image'}}
-    <img 
-        src="{{this}}"
-        {{#if config.parameters.0}}
-            width="{{config.parameters.0}}"
-        {{/if}}
-        {{#if config.parameters.1}}
-            height="{{config.parameters.1}}"
-        {{/if}}
-    />
+    {{#if this}}
+        <img
+            src="{{this}}"
+            {{#if config.parameters.0}}
+                width="{{config.parameters.0}}"
+            {{/if}}
+            {{#if config.parameters.1}}
+                height="{{config.parameters.1}}"
+            {{/if}}
+        />
+    {{/if}}
 {{/when}}
 {{#when config.format '===' 'email'}}
     <a href="mailto:{{this}}">{{compile config.parameters row}}</a>

--- a/src/Model/template/format/detail.html
+++ b/src/Model/template/format/detail.html
@@ -73,7 +73,15 @@
     <a href="{{compile config.parameters.0 row}}">{{compile config.parameters.1 row}}</a>
 {{/when}}
 {{#when config.format '===' 'image'}}
-    <img src="{{this}}" width="{{config.parameters.0}}" height="{{config.parameters.1}}" />
+    <img 
+        src="{{this}}"
+        {{#if config.parameters.0}}
+            width="{{config.parameters.0}}"
+        {{/if}}
+        {{#if config.parameters.1}}
+            height="{{config.parameters.1}}"
+        {{/if}}
+    />
 {{/when}}
 {{#when config.format '===' 'email'}}
     <a href="mailto:{{this}}">{{compile config.parameters row}}</a>

--- a/src/Model/template/format/detail.html
+++ b/src/Model/template/format/detail.html
@@ -204,6 +204,36 @@
         <div class="alert alert-info">{{_ 'Empty'}}</div>
     {{/if}}
 {{/when}}
+{{#when config.format '===' 'carousel'}}
+    {{#if this.length}}
+        <div
+            class="carousel slide"
+            data-do="carousel"
+            data-width="{{config.parameters.0}}"
+            data-height="{{config.parameters.1}}"
+        >
+            <div class="carousel-inner">
+                {{#each this}}
+                    <div class="carousel-item text-center {{#if @first}} active{{/if}}">
+                        <img
+                            class="m-auto"
+                            src="{{this}}"
+                            {{#if ../config.parameters.1}}
+                                height="{{../config.parameters.1}}"
+                            {{/if}}
+                        />
+                    </div>
+                {{/each}}
+            </div>
+            <a class="carousel-control-prev" role="button">
+                <i class="fas fa-chevron-left"></i>
+            </a>
+            <a class="carousel-control-next" role="button">
+                <i class="fas fa-chevron-right"></i>
+            </a>
+        </div>
+    {{/if}}
+{{/when}}
 {{#when config.format '===' 'jsonpretty'}}
     {{{json_pretty this}}}
 {{/when}}

--- a/src/Model/template/format/detail.html
+++ b/src/Model/template/format/detail.html
@@ -95,7 +95,7 @@
     {{{compile config.parameters row}}}
 {{/when}}
 {{#when config.format '===' 'comma'}}
-    {{join this ','}}
+    {{join this ', '}}
 {{/when}}
 {{#when config.format '===' 'space'}}
     {{join this ' '}}

--- a/src/Model/template/format/field.html
+++ b/src/Model/template/format/field.html
@@ -515,6 +515,12 @@
                     >
                         {{_ 'Choose File'}}
                     </button>
+                    <button
+                        class="file-field-link btn btn-success"
+                        type="button"
+                    >
+                        {{_ 'Choose URL'}}
+                    </button>
                 </td>
             </tr>
         </tfoot>
@@ -601,6 +607,12 @@
                     >
                         {{_ 'Choose Files'}}
                     </button>
+                    <button
+                        class="file-field-link btn btn-success"
+                        type="button"
+                    >
+                        {{_ 'Add URL'}}
+                    </button>
                 </td>
             </tr>
         </tfoot>
@@ -670,6 +682,12 @@
                         type="button"
                     >
                         {{_ 'Choose Image'}}
+                    </button>
+                    <button
+                        class="file-field-link btn btn-success"
+                        type="button"
+                    >
+                        {{_ 'Choose URL'}}
                     </button>
                 </td>
             </tr>
@@ -757,6 +775,12 @@
                         type="button"
                     >
                         {{_ 'Choose Images'}}
+                    </button>
+                    <button
+                        class="file-field-link btn btn-success"
+                        type="button"
+                    >
+                        {{_ 'Add URL'}}
                     </button>
                 </td>
             </tr>

--- a/src/Model/template/format/field.html
+++ b/src/Model/template/format/field.html
@@ -451,6 +451,17 @@
         {{/each}}
     </div>
 {{/when}}
+{{#when config.type '===' 'countrylist'}}
+    <select
+        class="form-control system-form-control"
+        data-do="country-dropdown"
+        name="{{@key}}"
+        {{#each config.attributes}}
+            {{@key}}="{{this}}"
+        {{/each}}
+    >
+    </select>
+{{/when}}
 {{#when config.type '===' 'file'}}
     <table
         class="table table-striped file-field"

--- a/src/Model/template/format/field.html
+++ b/src/Model/template/format/field.html
@@ -102,7 +102,7 @@
         {{#each config.attributes}}
             {{@key}}="{{this}}"
         {{/each}}
-    >{{{this}}}</textarea>
+    >{{{textarea this}}}</textarea>
 {{/when}}
 {{#when config.type '===' 'wysiwyg'}}
     <textarea
@@ -112,7 +112,7 @@
         {{#each config.attributes}}
             {{@key}}="{{this}}"
         {{/each}}
-    >{{{this}}}</textarea>
+    >{{{textarea this}}}</textarea>
 {{/when}}
 {{#when config.type '===' 'markdown'}}
     <textarea
@@ -132,7 +132,7 @@
         {{#each config.attributes}}
             {{@key}}="{{this}}"
         {{/each}}
-    >{{{this}}}</textarea>
+    >{{{textarea this}}}</textarea>
 {{/when}}
 {{#when config.type '===' 'number'}}
     <input

--- a/src/Model/template/format/field.html
+++ b/src/Model/template/format/field.html
@@ -1078,6 +1078,36 @@
         {{/each}}
     />
 {{/when}}
+{{#when config.type '===' 'latlng'}}
+    <input
+        autocomplete="{{name}}"
+        class="form-control system-form-control"
+        name="{{@key}}[0]"
+        type="number"
+        value="{{this.0}}"
+        min="-90"
+        max="90"
+        step="0.00000001"
+        placeholder="Latitude"
+        {{#each config.attributes}}
+            {{@key}}="{{this}}"
+        {{/each}}
+    />
+    <input
+        autocomplete="{{name}}"
+        class="form-control system-form-control"
+        name="{{@key}}[1]"
+        type="number"
+        value="{{this.1}}"
+        min="-180"
+        max="180"
+        step="0.00000001"
+        placeholder="Longitude"
+        {{#each config.attributes}}
+            {{@key}}="{{this}}"
+        {{/each}}
+    />
+{{/when}}
 {{#when config.type '===' 'rawjson'}}
     <textarea
         class="form-control hidden system-form-control"

--- a/src/Model/template/format/list.html
+++ b/src/Model/template/format/list.html
@@ -169,6 +169,36 @@
         <div class="alert alert-info m-0">{{_ 'Empty'}}</div>
     {{/if}}
 {{/when}}
+{{#when config.format '===' 'carousel'}}
+    {{#if this.length}}
+        <div
+            class="carousel slide"
+            data-do="carousel"
+            data-width="{{config.parameters.0}}"
+            data-height="{{config.parameters.1}}"
+        >
+            <div class="carousel-inner">
+                {{#each this}}
+                    <div class="carousel-item text-center {{#if @first}} active{{/if}}">
+                        <img 
+                            class="m-auto"
+                            src="{{this}}"
+                            {{#if ../config.parameters.1}}
+                                height="{{../config.parameters.1}}"
+                            {{/if}}
+                        />
+                    </div>
+                {{/each}}
+            </div>
+            <a class="carousel-control-prev" role="button">
+                <i class="fas fa-chevron-left"></i>
+            </a>
+            <a class="carousel-control-next" role="button">
+                <i class="fas fa-chevron-right"></i>
+            </a>
+        </div>
+    {{/if}}
+{{/when}}
 {{#when config.format '===' 'jsonpretty'}}
     {{{json_pretty this}}}
 {{/when}}

--- a/src/Model/template/format/list.html
+++ b/src/Model/template/format/list.html
@@ -73,15 +73,17 @@
     <a href="{{compile config.parameters.0 row}}">{{compile config.parameters.1 row}}</a>
 {{/when}}
 {{#when config.format '===' 'image'}}
-    <img
-        src="{{this}}"
-        {{#if config.parameters.0}}
-            width="{{config.parameters.0}}"
-        {{/if}}
-        {{#if config.parameters.1}}
-            height="{{config.parameters.1}}"
-        {{/if}}
-    />
+    {{#if this}}
+        <img
+            src="{{this}}"
+            {{#if config.parameters.0}}
+                width="{{config.parameters.0}}"
+            {{/if}}
+            {{#if config.parameters.1}}
+                height="{{config.parameters.1}}"
+            {{/if}}
+        />
+    {{/if}}
 {{/when}}
 {{#when config.format '===' 'email'}}
     <a href="mailto:{{this}}">{{compile config.parameters row}}</a>

--- a/src/Model/template/format/list.html
+++ b/src/Model/template/format/list.html
@@ -95,7 +95,7 @@
     {{{compile config.parameters row}}}
 {{/when}}
 {{#when config.format '===' 'comma'}}
-    {{join this ','}}
+    {{join this ', '}}
 {{/when}}
 {{#when config.format '===' 'space'}}
     {{join this ' '}}

--- a/src/Model/template/format/list.html
+++ b/src/Model/template/format/list.html
@@ -73,7 +73,15 @@
     <a href="{{compile config.parameters.0 row}}">{{compile config.parameters.1 row}}</a>
 {{/when}}
 {{#when config.format '===' 'image'}}
-    <img src="{{this}}" width="{{config.parameters.0}}" height="{{config.parameters.1}}" />
+    <img
+        src="{{this}}"
+        {{#if config.parameters.0}}
+            width="{{config.parameters.0}}"
+        {{/if}}
+        {{#if config.parameters.1}}
+            height="{{config.parameters.1}}"
+        {{/if}}
+    />
 {{/when}}
 {{#when config.format '===' 'email'}}
     <a href="mailto:{{this}}">{{compile config.parameters row}}</a>

--- a/src/Model/template/search/_filters.html
+++ b/src/Model/template/search/_filters.html
@@ -3,432 +3,434 @@
         {{#notin 'password,files,images,textarea,wysiwyg,markdown,code,none,hide,active' field.type}}
             <div class="form-group">
                 <label for="filter[{{@key}}]">{{label}}</label>
-                {{#in 'text,slug,file,image,uuid' field.type}}
-                    <input
-                        class="form-control"
-                        name="filter[{{@key}}]"
-                        type="text"
-                        value="{{scope ../filter @key}}"
-                        {{#each field.attributes}}
-                            {{@key}}="{{this}}"
-                        {{/each}}
-                    />
-                {{/in}}
-                {{#in 'email,search,url,color,week,month' field.type}}
-                    <input
-                        class="form-control"
-                        name="filter[{{@key}}]"
-                        type="{{field.type}}"
-                        value="{{scope ../filter @key}}"
-                        {{#each field.attributes}}
-                            {{@key}}="{{this}}"
-                        {{/each}}
-                    />
-                {{/in}}
-                {{#when field.type '===' 'mask'}}
-                    <input
-                        class="form-control"
-                        data-do="mask-field"
-                        name="filter[{{@key}}]"
-                        type="text"
-                        value="{{scope ../filter @key}}"
-                        {{#each field.attributes}}
-                            {{@key}}="{{this}}"
-                        {{/each}}
-                    />
-                {{/when}}
-                {{#when field.type '===' 'number'}}
-                    <div class="form-row">
-                        <div class="form-group col-md-6">
-                            <input
-                                class="form-control"
-                                name="span[{{@key}}][0]"
-                                type="number"
-                                value="{{#scope ../span @key}}{{0}}{{/scope}}"
-                                {{#each field.attributes}}
-                                    {{@key}}="{{this}}"
-                                {{/each}}
-                            />
-                            <label for="span[{{@key}}][0]">Min</label>
-                        </div>
-                        <div class="form-group col-md-6">
-                            <input
-                                class="form-control"
-                                name="span[{{@key}}][1]"
-                                type="number"
-                                value="{{#scope ../span @key}}{{1}}{{/scope}}"
-                                {{#each field.attributes}}
-                                    {{@key}}="{{this}}"
-                                {{/each}}
-                            />
-                            <label for="span[{{@key}}][1]">Max</label>
-                        </div>
-                    </div>
-                {{/when}}
-                {{#when field.type '===' 'small'}}
-                    <div class="form-row">
-                        <div class="form-group col-md-6">
-                            <input
-                                class="form-control"
-                                max="9"
-                                min="0"
-                                name="span[{{@key}}][0]"
-                                step="1"
-                                type="number"
-                                value="{{#scope ../span @key}}{{0}}{{/scope}}"
-                                {{#each field.attributes}}
-                                    {{@key}}="{{this}}"
-                                {{/each}}
-                            />
-                            <label for="span[{{@key}}][0]">Min</label>
-                        </div>
-                        <div class="form-group col-md-6">
-                            <input
-                                class="form-control"
-                                max="9"
-                                min="0"
-                                name="span[{{@key}}][1]"
-                                step="1"
-                                type="number"
-                                value="{{#scope ../span @key}}{{1}}{{/scope}}"
-                                {{#each field.attributes}}
-                                    {{@key}}="{{this}}"
-                                {{/each}}
-                            />
-                            <label for="span[{{@key}}][1]">Max</label>
-                        </div>
-                    </div>
-                {{/when}}
-                {{#when field.type '===' 'float'}}
-                    <div class="form-row">
-                        <div class="form-group col-md-6">
-                            <input
-                                class="form-control"
-                                name="span[{{@key}}][0]"
-                                step="0.00001"
-                                type="number"
-                                value="{{#scope ../span @key}}{{0}}{{/scope}}"
-                                {{#each field.attributes}}
-                                    {{@key}}="{{this}}"
-                                {{/each}}
-                            />
-                            <label for="span[{{@key}}][0]">Min</label>
-                        </div>
-                        <div class="form-group col-md-6">
-                            <input
-                                class="form-control"
-                                name="span[{{@key}}][1]"
-                                step="0.00001"
-                                type="number"
-                                value="{{#scope ../span @key}}{{1}}{{/scope}}"
-                                {{#each field.attributes}}
-                                    {{@key}}="{{this}}"
-                                {{/each}}
-                            />
-                            <label for="span[{{@key}}][1]">Max</label>
-                        </div>
-                    </div>
-                {{/when}}
-                {{#when field.type '===' 'price'}}
-                    <div class="form-row">
-                        <div class="form-group col-md-6">
-                            <input
-                                class="form-control"
-                                name="span[{{@key}}][0]"
-                                step="0.01"
-                                type="number"
-                                value="{{#scope ../span @key}}{{0}}{{/scope}}"
-                                {{#each field.attributes}}
-                                    {{@key}}="{{this}}"
-                                {{/each}}
-                            />
-                            <label for="span[{{@key}}][0]">Min</label>
-                        </div>
-                        <div class="form-group col-md-6">
-                            <input
-                                class="form-control"
-                                name="span[{{@key}}][1]"
-                                step="0.01"
-                                type="number"
-                                value="{{#scope ../span @key}}{{1}}{{/scope}}"
-                                {{#each field.attributes}}
-                                    {{@key}}="{{this}}"
-                                {{/each}}
-                            />
-                            <label for="span[{{@key}}][1]">Max</label>
-                        </div>
-                    </div>
-                {{/when}}
-                {{#when field.type '===' 'range'}}
-                    <input
-                        class="irs-hidden-input"
-                        data-do="multirange-field"
-                        name="filter[{{@key}}]"
-                        tabindex="-1"
-                        type="hidden"
-                        value="{{scope ../filter @key}}"
-                        {{#each field.attributes}}
-                            {{@key}}="{{this}}"
-                        {{/each}}
-                    />
-                {{/when}}
-                {{#when field.type '===' 'date'}}
-                    <div class="form-row">
-                        <div class="form-group col-md-6">
-                            <input
-                                aria-haspopup="true"
-                                aria-expanded="false"
-                                class="form-control date"
-                                data-do="date-field"
-                                name="span[{{@key}}][0]"
-                                type="text"
-                                value="{{#scope ../span @key}}{{0}}{{/scope}}"
-                                {{#each field.attributes}}
-                                    {{@key}}="{{this}}"
-                                {{/each}}
-                            />
-                            <label for="span[{{@key}}][0]">Start Date</label>
-                        </div>
-                        <div class="form-group col-md-6">
-                            <input
-                                aria-haspopup="true"
-                                aria-expanded="false"
-                                class="form-control date"
-                                data-do="date-field"
-                                name="span[{{@key}}][1]"
-                                type="text"
-                                value="{{#scope ../span @key}}{{1}}{{/scope}}"
-                                {{#each field.attributes}}
-                                    {{@key}}="{{this}}"
-                                {{/each}}
-                            />
-                            <label for="span[{{@key}}][1]">End Date</label>
-                        </div>
-                    </div>
-                {{/when}}
-                {{#when field.type '===' 'time'}}
-                    <div class="form-row">
-                        <div class="form-group col-md-6">
-                            <input
-                                aria-haspopup="true"
-                                aria-expanded="false"
-                                class="form-control date"
-                                data-do="time-field"
-                                name="span[{{@key}}][0]"
-                                type="text"
-                                value="{{#scope ../span @key}}{{0}}{{/scope}}"
-                                {{#each field.attributes}}
-                                    {{@key}}="{{this}}"
-                                {{/each}}
-                            />
-                            <label for="span[{{@key}}][0]">Start Time</label>
-                        </div>
-                        <div class="form-group col-md-6">
-                            <input
-                                aria-haspopup="true"
-                                aria-expanded="false"
-                                class="form-control date"
-                                data-do="time-field"
-                                name="span[{{@key}}][1]"
-                                type="text"
-                                value="{{#scope ../span @key}}{{1}}{{/scope}}"
-                                {{#each field.attributes}}
-                                    {{@key}}="{{this}}"
-                                {{/each}}
-                            />
-                            <label for="span[{{@key}}][1]">End Time</label>
-                        </div>
-                    </div>
-                {{/when}}
-                {{#when field.type '===' 'datetime'}}
-                    <div class="form-row">
-                        <div class="form-group col-md-6">
-                            <input
-                                aria-haspopup="true"
-                                aria-expanded="false"
-                                class="form-control date"
-                                data-do="datetime-field"
-                                name="span[{{@key}}][0]"
-                                type="text"
-                                value="{{#scope ../span @key}}{{0}}{{/scope}}"
-                                {{#each field.attributes}}
-                                    {{@key}}="{{this}}"
-                                {{/each}}
-                            />
-                            <label for="span[{{@key}}][0]">Start Date</label>
-                        </div>
-                        <div class="form-group col-md-6">
-                            <input
-                                aria-haspopup="true"
-                                aria-expanded="false"
-                                class="form-control date"
-                                data-do="datetime-field"
-                                name="span[{{@key}}][1]"
-                                type="text"
-                                value="{{#scope ../span @key}}{{1}}{{/scope}}"
-                                {{#each field.attributes}}
-                                    {{@key}}="{{this}}"
-                                {{/each}}
-                            />
-                            <label for="span[{{@key}}][1]">End Date</label>
-                        </div>
-                    </div>
-                {{/when}}
-                {{#when field.type '===' 'checkbox'}}
-                    <label class="checkbox checkbox-2">
+                <div>
+                    {{#in 'text,slug,file,image,uuid,ipaddress,countrylist' field.type}}
                         <input
+                            class="form-control"
                             name="filter[{{@key}}]"
-                            type="checkbox"
-                            value="1"
-                            {{#when ../filter @key '==' 1}}checked{{/when}}
+                            type="text"
+                            value="{{scope ../filter @key}}"
                             {{#each field.attributes}}
                                 {{@key}}="{{this}}"
                             {{/each}}
                         />
-                        <span>{{field.attributes.placeholder}}</span>
-                    </label>
-                {{/when}}
-                {{#when field.type '===' 'switch'}}
-                    <input
-                        name="{{@key}}"
-                        type="hidden"
-                        value="0"
-                    />
-                    <label class="switch switch-1">
+                    {{/in}}
+                    {{#in 'email,search,url,color,week,month' field.type}}
                         <input
+                            class="form-control"
                             name="filter[{{@key}}]"
-                            type="checkbox"
-                            value="1"
-                            {{#when ../filter @key '==' 1}}checked{{/when}}
+                            type="{{field.type}}"
+                            value="{{scope ../filter @key}}"
                             {{#each field.attributes}}
                                 {{@key}}="{{this}}"
                             {{/each}}
                         />
-                        <span>{{field.attributes.placeholder}}</span>
-                    </label>
-                {{/when}}
-                {{#when field.type '===' 'knob'}}
-                    <input
-                        class="form-control"
-                        data-do="knob-field"
-                        name="filter[{{@key}}]"
-                        type="text"
-                        value="{{scope ../filter @key}}"
-                        {{#each field.attributes}}
-                            {{@key}}="{{this}}"
-                        {{/each}}
-                    />
-                {{/when}}
-                {{#when field.type '===' 'select'}}
-                    <select
-                        class="form-control"
-                        name="filter[{{@key}}]"
-                        {{#each field.attributes}}
-                            {{@key}}="{{this}}"
-                        {{/each}}
-                    >
-                        <option value="">Choose One</option>
-                        {{#each field.options}}
-                            <option
-                                value="{{./key}}"
-                                {{#when ../../filter ../@key '==' key}}selected{{/when}}
-                            >
-                                {{value}}
-                            </option>
-                        {{/each}}
-                    </select>
-                {{/when}}
-                {{#when field.type '===' 'multiselect'}}
-                    <select
-                        class="form-control"
-                        data-do="select-field"
-                        multiple="multiple"
-                        name="multiple[{{@key}}][]"
-                        {{#each field.attributes}}
-                            {{@key}}="{{this}}"
-                        {{/each}}
-                    >
-                        {{#each field.options}}
-                            <option
-                                value="{{./key}}"
-                                {{#when ../../multiple ../@key '==' key}}selected{{/when}}
-                            >
-                                {{value}}
-                            </option>
-                        {{/each}}
-                    </select>
-                {{/when}}
-                {{#when field.type '===' 'checkboxes'}}
-                    <div{{#each field.attributes}} {{@key}}="{{this}}"{{/each}}>
-                        {{#each field.options}}
-                            <label class="checkbox checkbox-2">
+                    {{/in}}
+                    {{#when field.type '===' 'mask'}}
+                        <input
+                            class="form-control"
+                            data-do="mask-field"
+                            name="filter[{{@key}}]"
+                            type="text"
+                            value="{{scope ../filter @key}}"
+                            {{#each field.attributes}}
+                                {{@key}}="{{this}}"
+                            {{/each}}
+                        />
+                    {{/when}}
+                    {{#when field.type '===' 'number'}}
+                        <div class="form-row">
+                            <div class="form-group col-md-6">
                                 <input
-                                    name="multiple[{{@key}}][]"
-                                    type="checkbox"
-                                    value="{{./key}}"
-                                    {{#when ../../multiple ../@key '==' key}}checked{{/when}}
+                                    class="form-control"
+                                    name="span[{{@key}}][0]"
+                                    type="number"
+                                    value="{{#scope ../span @key}}{{0}}{{/scope}}"
+                                    {{#each field.attributes}}
+                                        {{@key}}="{{this}}"
+                                    {{/each}}
                                 />
-                                <span>{{value}}</span>
-                            </label>
-                        {{/each}}
-                    </div>
-                {{/when}}
-                {{#when field.type '===' 'radios'}}
-                    <div{{#each field.attributes}} {{@key}}="{{this}}"{{/each}}>
-                        {{#each field.options}}
-                            <label class="radio radio-2">
-                                <input
-                                    name="filter[{{@key}}]"
-                                    type="radio"
-                                    value="{{./key}}"
-                                    {{#when ../../filter ../@key '==' key}}checked{{/when}}
-                                />
-                                <span>{{value}}</span>
-                            </label>
-                        {{/each}}
-                    </div>
-                {{/when}}
-                {{#when field.type '===' 'tag'}}
-                    <div
-                        data-do="tag-field"
-                        class="tag-field"
-                        data-name="multiple[{{@key}}]"
-                        {{#each field.attributes}}
-                            {{@key}}="{{this}}"
-                        {{/each}}
-                    >
-                        {{#loop ../item @key}}
-                            <div class="tag">
-                                <input
-                                    class="tag-input text-field"
-                                    type="text"
-                                    name="multiple[{{../@key}}][]"
-                                    value="{{this}}"
-                                />
-                                <a
-                                    class="remove"
-                                    href="javascript:void(0)"
-                                >
-                                    <i class="fa fa-times"></i>
-                                </a>
+                                <label for="span[{{@key}}][0]">Min</label>
                             </div>
-                        {{/loop}}
-                    </div>
-                {{/when}}
-                {{#when field.type '===' 'multirange'}}
-                    <input
-                        class="irs-hidden-input"
-                        data-do="multirange-field"
-                        data-type="double"
-                        name="filter[{{@key}}]"
-                        tabindex="-1"
-                        type="hidden"
-                        value="{{scope ../filter @key}}"
-                        {{#each field.attributes}}
-                            {{@key}}="{{this}}"
-                        {{/each}}
-                    />
-                {{/when}}
+                            <div class="form-group col-md-6">
+                                <input
+                                    class="form-control"
+                                    name="span[{{@key}}][1]"
+                                    type="number"
+                                    value="{{#scope ../span @key}}{{1}}{{/scope}}"
+                                    {{#each field.attributes}}
+                                        {{@key}}="{{this}}"
+                                    {{/each}}
+                                />
+                                <label for="span[{{@key}}][1]">Max</label>
+                            </div>
+                        </div>
+                    {{/when}}
+                    {{#when field.type '===' 'small'}}
+                        <div class="form-row">
+                            <div class="form-group col-md-6">
+                                <input
+                                    class="form-control"
+                                    max="9"
+                                    min="0"
+                                    name="span[{{@key}}][0]"
+                                    step="1"
+                                    type="number"
+                                    value="{{#scope ../span @key}}{{0}}{{/scope}}"
+                                    {{#each field.attributes}}
+                                        {{@key}}="{{this}}"
+                                    {{/each}}
+                                />
+                                <label for="span[{{@key}}][0]">Min</label>
+                            </div>
+                            <div class="form-group col-md-6">
+                                <input
+                                    class="form-control"
+                                    max="9"
+                                    min="0"
+                                    name="span[{{@key}}][1]"
+                                    step="1"
+                                    type="number"
+                                    value="{{#scope ../span @key}}{{1}}{{/scope}}"
+                                    {{#each field.attributes}}
+                                        {{@key}}="{{this}}"
+                                    {{/each}}
+                                />
+                                <label for="span[{{@key}}][1]">Max</label>
+                            </div>
+                        </div>
+                    {{/when}}
+                    {{#when field.type '===' 'float'}}
+                        <div class="form-row">
+                            <div class="form-group col-md-6">
+                                <input
+                                    class="form-control"
+                                    name="span[{{@key}}][0]"
+                                    step="0.00001"
+                                    type="number"
+                                    value="{{#scope ../span @key}}{{0}}{{/scope}}"
+                                    {{#each field.attributes}}
+                                        {{@key}}="{{this}}"
+                                    {{/each}}
+                                />
+                                <label for="span[{{@key}}][0]">Min</label>
+                            </div>
+                            <div class="form-group col-md-6">
+                                <input
+                                    class="form-control"
+                                    name="span[{{@key}}][1]"
+                                    step="0.00001"
+                                    type="number"
+                                    value="{{#scope ../span @key}}{{1}}{{/scope}}"
+                                    {{#each field.attributes}}
+                                        {{@key}}="{{this}}"
+                                    {{/each}}
+                                />
+                                <label for="span[{{@key}}][1]">Max</label>
+                            </div>
+                        </div>
+                    {{/when}}
+                    {{#when field.type '===' 'price'}}
+                        <div class="form-row">
+                            <div class="form-group col-md-6">
+                                <input
+                                    class="form-control"
+                                    name="span[{{@key}}][0]"
+                                    step="0.01"
+                                    type="number"
+                                    value="{{#scope ../span @key}}{{0}}{{/scope}}"
+                                    {{#each field.attributes}}
+                                        {{@key}}="{{this}}"
+                                    {{/each}}
+                                />
+                                <label for="span[{{@key}}][0]">Min</label>
+                            </div>
+                            <div class="form-group col-md-6">
+                                <input
+                                    class="form-control"
+                                    name="span[{{@key}}][1]"
+                                    step="0.01"
+                                    type="number"
+                                    value="{{#scope ../span @key}}{{1}}{{/scope}}"
+                                    {{#each field.attributes}}
+                                        {{@key}}="{{this}}"
+                                    {{/each}}
+                                />
+                                <label for="span[{{@key}}][1]">Max</label>
+                            </div>
+                        </div>
+                    {{/when}}
+                    {{#when field.type '===' 'range'}}
+                        <input
+                            class="irs-hidden-input"
+                            data-do="multirange-field"
+                            name="filter[{{@key}}]"
+                            tabindex="-1"
+                            type="hidden"
+                            value="{{scope ../filter @key}}"
+                            {{#each field.attributes}}
+                                {{@key}}="{{this}}"
+                            {{/each}}
+                        />
+                    {{/when}}
+                    {{#when field.type '===' 'date'}}
+                        <div class="form-row">
+                            <div class="form-group col-md-6">
+                                <input
+                                    aria-haspopup="true"
+                                    aria-expanded="false"
+                                    class="form-control date"
+                                    data-do="date-field"
+                                    name="span[{{@key}}][0]"
+                                    type="text"
+                                    value="{{#scope ../span @key}}{{0}}{{/scope}}"
+                                    {{#each field.attributes}}
+                                        {{@key}}="{{this}}"
+                                    {{/each}}
+                                />
+                                <label for="span[{{@key}}][0]">Start Date</label>
+                            </div>
+                            <div class="form-group col-md-6">
+                                <input
+                                    aria-haspopup="true"
+                                    aria-expanded="false"
+                                    class="form-control date"
+                                    data-do="date-field"
+                                    name="span[{{@key}}][1]"
+                                    type="text"
+                                    value="{{#scope ../span @key}}{{1}}{{/scope}}"
+                                    {{#each field.attributes}}
+                                        {{@key}}="{{this}}"
+                                    {{/each}}
+                                />
+                                <label for="span[{{@key}}][1]">End Date</label>
+                            </div>
+                        </div>
+                    {{/when}}
+                    {{#when field.type '===' 'time'}}
+                        <div class="form-row">
+                            <div class="form-group col-md-6">
+                                <input
+                                    aria-haspopup="true"
+                                    aria-expanded="false"
+                                    class="form-control date"
+                                    data-do="time-field"
+                                    name="span[{{@key}}][0]"
+                                    type="text"
+                                    value="{{#scope ../span @key}}{{0}}{{/scope}}"
+                                    {{#each field.attributes}}
+                                        {{@key}}="{{this}}"
+                                    {{/each}}
+                                />
+                                <label for="span[{{@key}}][0]">Start Time</label>
+                            </div>
+                            <div class="form-group col-md-6">
+                                <input
+                                    aria-haspopup="true"
+                                    aria-expanded="false"
+                                    class="form-control date"
+                                    data-do="time-field"
+                                    name="span[{{@key}}][1]"
+                                    type="text"
+                                    value="{{#scope ../span @key}}{{1}}{{/scope}}"
+                                    {{#each field.attributes}}
+                                        {{@key}}="{{this}}"
+                                    {{/each}}
+                                />
+                                <label for="span[{{@key}}][1]">End Time</label>
+                            </div>
+                        </div>
+                    {{/when}}
+                    {{#when field.type '===' 'datetime'}}
+                        <div class="form-row">
+                            <div class="form-group col-md-6">
+                                <input
+                                    aria-haspopup="true"
+                                    aria-expanded="false"
+                                    class="form-control date"
+                                    data-do="datetime-field"
+                                    name="span[{{@key}}][0]"
+                                    type="text"
+                                    value="{{#scope ../span @key}}{{0}}{{/scope}}"
+                                    {{#each field.attributes}}
+                                        {{@key}}="{{this}}"
+                                    {{/each}}
+                                />
+                                <label for="span[{{@key}}][0]">Start Date</label>
+                            </div>
+                            <div class="form-group col-md-6">
+                                <input
+                                    aria-haspopup="true"
+                                    aria-expanded="false"
+                                    class="form-control date"
+                                    data-do="datetime-field"
+                                    name="span[{{@key}}][1]"
+                                    type="text"
+                                    value="{{#scope ../span @key}}{{1}}{{/scope}}"
+                                    {{#each field.attributes}}
+                                        {{@key}}="{{this}}"
+                                    {{/each}}
+                                />
+                                <label for="span[{{@key}}][1]">End Date</label>
+                            </div>
+                        </div>
+                    {{/when}}
+                    {{#when field.type '===' 'checkbox'}}
+                        <label class="checkbox checkbox-2">
+                            <input
+                                name="filter[{{@key}}]"
+                                type="checkbox"
+                                value="1"
+                                {{#when ../filter @key '==' 1}}checked{{/when}}
+                                {{#each field.attributes}}
+                                    {{@key}}="{{this}}"
+                                {{/each}}
+                            />
+                            <span>{{field.attributes.placeholder}}</span>
+                        </label>
+                    {{/when}}
+                    {{#when field.type '===' 'switch'}}
+                        <input
+                            name="{{@key}}"
+                            type="hidden"
+                            value="0"
+                        />
+                        <label class="switch switch-1">
+                            <input
+                                name="filter[{{@key}}]"
+                                type="checkbox"
+                                value="1"
+                                {{#when ../filter @key '==' 1}}checked{{/when}}
+                                {{#each field.attributes}}
+                                    {{@key}}="{{this}}"
+                                {{/each}}
+                            />
+                            <span>{{field.attributes.placeholder}}</span>
+                        </label>
+                    {{/when}}
+                    {{#when field.type '===' 'knob'}}
+                        <input
+                            class="form-control"
+                            data-do="knob-field"
+                            name="filter[{{@key}}]"
+                            type="text"
+                            value="{{scope ../filter @key}}"
+                            {{#each field.attributes}}
+                                {{@key}}="{{this}}"
+                            {{/each}}
+                        />
+                    {{/when}}
+                    {{#when field.type '===' 'select'}}
+                        <select
+                            class="form-control"
+                            name="filter[{{@key}}]"
+                            {{#each field.attributes}}
+                                {{@key}}="{{this}}"
+                            {{/each}}
+                        >
+                            <option value="">Choose One</option>
+                            {{#each field.options}}
+                                <option
+                                    value="{{./key}}"
+                                    {{#when ../../filter ../@key '==' key}}selected{{/when}}
+                                >
+                                    {{value}}
+                                </option>
+                            {{/each}}
+                        </select>
+                    {{/when}}
+                    {{#when field.type '===' 'multiselect'}}
+                        <select
+                            class="form-control"
+                            data-do="select-field"
+                            multiple="multiple"
+                            name="multiple[{{@key}}][]"
+                            {{#each field.attributes}}
+                                {{@key}}="{{this}}"
+                            {{/each}}
+                        >
+                            {{#each field.options}}
+                                <option
+                                    value="{{./key}}"
+                                    {{#when ../../multiple ../@key '==' key}}selected{{/when}}
+                                >
+                                    {{value}}
+                                </option>
+                            {{/each}}
+                        </select>
+                    {{/when}}
+                    {{#when field.type '===' 'checkboxes'}}
+                        <div{{#each field.attributes}} {{@key}}="{{this}}"{{/each}}>
+                            {{#each field.options}}
+                                <label class="checkbox checkbox-2">
+                                    <input
+                                        name="multiple[{{@key}}][]"
+                                        type="checkbox"
+                                        value="{{./key}}"
+                                        {{#when ../../multiple ../@key '==' key}}checked{{/when}}
+                                    />
+                                    <span>{{value}}</span>
+                                </label>
+                            {{/each}}
+                        </div>
+                    {{/when}}
+                    {{#when field.type '===' 'radios'}}
+                        <div{{#each field.attributes}} {{@key}}="{{this}}"{{/each}}>
+                            {{#each field.options}}
+                                <label class="radio radio-2">
+                                    <input
+                                        name="filter[{{@key}}]"
+                                        type="radio"
+                                        value="{{./key}}"
+                                        {{#when ../../filter ../@key '==' key}}checked{{/when}}
+                                    />
+                                    <span>{{value}}</span>
+                                </label>
+                            {{/each}}
+                        </div>
+                    {{/when}}
+                    {{#when field.type '===' 'tag'}}
+                        <div
+                            data-do="tag-field"
+                            class="tag-field"
+                            data-name="multiple[{{@key}}]"
+                            {{#each field.attributes}}
+                                {{@key}}="{{this}}"
+                            {{/each}}
+                        >
+                            {{#loop ../item @key}}
+                                <div class="tag">
+                                    <input
+                                        class="tag-input text-field"
+                                        type="text"
+                                        name="multiple[{{../@key}}][]"
+                                        value="{{this}}"
+                                    />
+                                    <a
+                                        class="remove"
+                                        href="javascript:void(0)"
+                                    >
+                                        <i class="fa fa-times"></i>
+                                    </a>
+                                </div>
+                            {{/loop}}
+                        </div>
+                    {{/when}}
+                    {{#when field.type '===' 'multirange'}}
+                        <input
+                            class="irs-hidden-input"
+                            data-do="multirange-field"
+                            data-type="double"
+                            name="filter[{{@key}}]"
+                            tabindex="-1"
+                            type="hidden"
+                            value="{{scope ../filter @key}}"
+                            {{#each field.attributes}}
+                                {{@key}}="{{this}}"
+                            {{/each}}
+                        />
+                    {{/when}}
+                </div>
             </div>
         {{/notin}}
     {{/in}}

--- a/src/Relation/events.php
+++ b/src/Relation/events.php
@@ -155,7 +155,7 @@ $this->on('system-relation-unlink', function ($request, $response) {
  * @param Request $request
  * @param Response $response
  */
-$this->on('system-relation-unlinkall', function ($request, $response) {
+$this->on('system-relation-unlink-all', function ($request, $response) {
     //----------------------------//
     // 1. Get Data
     //get data from stage

--- a/src/Schema.php
+++ b/src/Schema.php
@@ -85,6 +85,7 @@ class Schema extends Fieldset
             'fields' => $this->getFields(),
             'files' => $this->getFileFieldNames(),
             'json' => $this->getJsonFieldNames(),
+            'ipaddress' => $this->getIPAddressFieldName(),
             'listable' => $this->getListableFieldNames(),
             'detailable' => $this->getDetailableFieldNames(),
             'primary' => $this->getPrimaryFieldName(),
@@ -118,6 +119,27 @@ class Schema extends Fieldset
         $table = $this->data['name'];
         foreach ($this->data['fields'] as $field) {
             if ($field['name'] === 'created') {
+                return $table . '_' . $field['name'];
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * Returns IP address field
+     *
+     * @return string|false
+     */
+    public function getIPAddressFieldName()
+    {
+        if (!isset($this->data['fields']) || empty($this->data['fields'])) {
+            return false;
+        }
+
+        $table = $this->data['name'];
+        foreach ($this->data['fields'] as $field) {
+            if ($field['field']['type'] === 'ipaddress') {
                 return $table . '_' . $field['name'];
             }
         }
@@ -654,6 +676,10 @@ class Schema extends Fieldset
             'type' => 'VARCHAR',
             'length' => 255
         ],
+        'countrylist' => [
+            'type' => 'VARCHAR',
+            'length' => 255
+        ],
         'multiselect' => [
             'type' => 'JSON'
         ],
@@ -706,6 +732,10 @@ class Schema extends Fieldset
             'type' => 'JSON'
         ],
         'uuid' => [
+            'type' => 'VARCHAR',
+            'length' => 255
+        ],
+        'ipaddress' => [
             'type' => 'VARCHAR',
             'length' => 255
         ],

--- a/src/Schema.php
+++ b/src/Schema.php
@@ -722,6 +722,9 @@ class Schema extends Fieldset
         'multirange' => [
             'type' => 'JSON'
         ],
+        'latlng' => [
+            'type' => 'JSON'
+        ],
         'rawjson' => [
             'type' => 'JSON'
         ],

--- a/src/Schema/template/_scripts.html
+++ b/src/Schema/template/_scripts.html
@@ -224,6 +224,7 @@
             var filterable = option.attr('data-filterable');
             var sortable = option.attr('data-sortable');
             var validation = option.attr('data-validation');
+            var indexes = (option.attr('data-index') || '').split('|');
 
             //determine label
             if(label && label.length) {
@@ -296,6 +297,15 @@
             } else {
                 $('input.field-sortable', target).parent().show();
             }
+
+            //determine index
+            ['searchable', 'filterable', 'sortable'].forEach(function(index) {
+                if(indexes.indexOf(index) === -1) {
+                    $('input.field-' + index, target)
+                        .attr('checked', false)
+                        .attr('disabled', true);
+                }
+            });
         };
 
         //field type change
@@ -306,7 +316,6 @@
             //configuration
             var fieldsets = (option.attr('data-fieldset') || '').split('|');
             var formats = (option.attr('data-format') || '').split('|');
-            var indexes = (option.attr('data-index') || '').split('|');
             var index = $(this).getModelIndex();
 
             //reset
@@ -393,15 +402,6 @@
                     if($('option:selected', detail).length) {
                         detail.parent().val('none').trigger('change');
                     }
-                }
-            });
-
-            //determine index
-            ['searchable', 'filterable', 'sortable'].forEach(function(index) {
-                if(indexes.indexOf(index) === -1) {
-                    $('input.field-' + index, target)
-                        .attr('checked', false)
-                        .attr('disabled', true);
                 }
             });
 

--- a/src/Schema/template/_scripts.html
+++ b/src/Schema/template/_scripts.html
@@ -701,7 +701,7 @@
         var index = target.getModelIndex();
         var index2 = target.data('index');
 
-        $('a.remove', target).click(function() {
+        $('a.remove:first', target).click(function() {
             target.remove();
         });
 

--- a/src/Schema/template/_scripts.html
+++ b/src/Schema/template/_scripts.html
@@ -67,21 +67,6 @@
                 $(this).attr('data-name', name);
             });
 
-            $('input', copy).each(function() {
-                var value = $(this).val();
-                $(this).attr('value', value);
-            });
-
-            $('input', copy).each(function() {
-                var value = $(this).val();
-                $(this).attr('value', value);
-            });
-
-            $('textarea', copy).each(function() {
-                var value = $(this).val();
-                $(this).html(value);
-            });
-
             $('#modal-template')
                 .compile({INDEX: index})
                 .find('div.modal-body')
@@ -654,6 +639,8 @@
                     .removeClass('modal-create')
                     .addClass('modal-update')
                 );
+
+            $('h5.modal-title', modal).html('Edit Field');
         }
 
         var row = $(trigger).parents('tr.schema-field-row').eq(0);
@@ -1240,7 +1227,49 @@
 
     //----------------------------//
     // Functions
+    var $clone = $.fn.clone;
     $.fn.extend({
+        clone: function() {
+            //before cloning we need to set the html states for fields
+            //considerations
+            // input
+            // - checkbox
+            // - radio
+            // textarea
+            // select
+            $('input', this).each(function() {
+                $(this).attr('value', $(this).val());
+
+                var type = ($(this).attr('type') || 'text').toLowerCase();
+
+                if (type === 'radio' || type === 'checkbox') {
+                    var checked = $(this).prop('checked');
+                    if (checked) {
+                        $(this).attr('checked', 'checked');
+                    } else {
+                        $(this).removeAttr('checked');
+                    }
+                }
+            });
+
+            $('textarea', this).each(function() {
+                $(this).html($(this).val());
+            });
+
+            $('select', this).each(function() {
+                var selected = this.options[this.selectedIndex];
+                $('option', this).removeAttr('selected');
+
+                if (selected) {
+                    $(selected).attr('selected', 'selected');
+                }
+            });
+
+            var withDataAndEvents = arguments[0] || false;
+            var deepWithDataAndEvents = arguments[1] || false;
+            var clone = $clone.call(this, withDataAndEvents, deepWithDataAndEvents);
+            return clone;
+        },
         compile: function(variables) {
             var template = this.text();
 
@@ -1283,7 +1312,5 @@
             });
         }
     });
-
-    var copy = null;
 })(jQuery);
 </script>

--- a/src/Schema/template/options/_format.html
+++ b/src/Schema/template/options/_format.html
@@ -185,6 +185,15 @@
         Table
     </option>
     <option
+        data-fieldset="textpair"
+        data-placeholder-1="Width"
+        data-placeholder-2="Height"
+        value="carousel"
+        {{#when format '===' 'carousel'}}selected{{/when}}
+    >
+        Image Carousel
+    </option>
+    <option
         value="jsonpretty"
         {{#when format '===' 'jsonpretty'}}selected{{/when}}
     >

--- a/src/Schema/template/options/_type.html
+++ b/src/Schema/template/options/_type.html
@@ -270,6 +270,15 @@
     >
         Radios Fieldset
     </option>
+    <option
+        data-index="searchable|filterable|sortable"
+        data-fieldset="attributes"
+        data-format="string"
+        value="countrylist"
+        {{#when field.type '===' 'countrylist'}}selected{{/when}}
+    >
+        Country List Field
+    </option>
 </optgroup>
 <optgroup label="File Fields">
     <option
@@ -384,9 +393,9 @@
 <optgroup label="_________">
     <option
         data-default="1"
-        data-filterable="1"
+        data-filterable="0"
         data-format="string"
-        data-index="filterable|searchable"
+        data-index="searchable"
         data-searchable="1"
         data-sortable="0"
         data-validation="0"
@@ -394,6 +403,19 @@
         {{#when field.type '===' 'uuid'}}selected{{/when}}
     >
         Unique ID
+    </option>
+    <option
+        data-default="0.0.0.0"
+        data-filterable="1"
+        data-format="string"
+        data-index="filterable|searchable"
+        data-searchable="1"
+        data-sortable="0"
+        data-validation="0"
+        value="ipaddress"
+        {{#when field.type '===' 'ipaddress'}}selected{{/when}}
+    >
+        IP Address
     </option>
     <option
         data-default="1"

--- a/src/Schema/template/options/_type.html
+++ b/src/Schema/template/options/_type.html
@@ -374,6 +374,14 @@
         Multi Range Field
     </option>
     <option
+        data-fieldset="attributes"
+        data-format="json"
+        value="latlng"
+        {{#when field.type '===' 'latlng'}}selected{{/when}}
+    >
+        Lat/Lng
+    </option>
+    <option
         data-fieldset="attributes|fieldset"
         data-format="json"
         value="fieldset"

--- a/src/bootstrap/helpers.php
+++ b/src/bootstrap/helpers.php
@@ -86,6 +86,7 @@ return function($request, $response) {
                     || ($type === 'field' && $field[$type]['type'] === 'active')
                     || ($type === 'field' && $field[$type]['type'] === 'created')
                     || ($type === 'field' && $field[$type]['type'] === 'updated')
+                    || ($type === 'field' && $field[$type]['type'] === 'ipaddress')
                     || ($type === 'field' && $field[$type]['type'] === 'uuid')
                     || ($type === 'list' && $field[$type]['format'] === 'hide')
                     || ($type === 'detail' && $field[$type]['format'] === 'hide')

--- a/src/bootstrap/helpers.php
+++ b/src/bootstrap/helpers.php
@@ -553,6 +553,10 @@ return function($request, $response) {
         return implode('', $buffer);
     });
 
+    $handlebars->registerHelper('textarea', function($string) {
+        return str_replace('</textarea>', '<\/textarea>', $string);
+    });
+
     $handlebars->registerHelper('scope_dot', function ($array, $dot, $options) {
         if (!is_array($array)) {
             return $options['inverse']();


### PR DESCRIPTION
 - renaming `relation-unlink-all` event
 - Fix for CradlePHP/Cradle#213 1:1 Autocomplete not working on relational create form
 - Fix for CradlePHP/Cradle#208 Removing validation option, removes the entire validation
 - When choosing the image output format, you can now set height or width to 0 to make it auto size
 - Fix for CradlePHP/Cradle#212 Copy field in schema create/update form does not copy the indexes
 - Fix for CradlePHP/Cradle#214 Text List field not working on a fieldset
 - Image format fix, when no image and adding URL button on file fields
 - Fix for textarea inside a textarea
 - Adding IP address field. see CradlePHP/Cradle#211
 - Adding country field. see CradlePHP/Cradle#194
 - Adding Lat/Lng field. see CradlePHP/Cradle#210
 - Adding carousel format. see CradlePHP/Cradle#178
 - Fix for CradlePHP/Cradle#209 warning when removing or restoring a fieldset