### PR TITLE
Fieldsets and Schema Logic Change

### DIFF
--- a/src/Fieldset/Validator.php
+++ b/src/Fieldset/Validator.php
@@ -47,14 +47,10 @@ class Validator
         }
 
         if (isset($data['name'])) {
-            $exists = false;
-            try {
-                $exists = Fieldset::i($data['name'])->getAll();
-            } catch (Exception $e) {
-            }
+            $exists = cradle('global')->fieldset($data['name']);
 
-            if ($exists) {
-                $errors['name'] = 'Keyword is already in used.';
+            if (!empty($exists)) {
+                $errors['name'] = 'Keyword is already used.';
             }
         }
 

--- a/src/Fieldset/template/_templates.html
+++ b/src/Fieldset/template/_templates.html
@@ -175,7 +175,7 @@
             </select>
             <span class="input-group-btn">
                 <a
-                    class="btn btn-danger"
+                    class="btn btn-danger remove"
                     href="javascript:void(0)"
                 >
                     <i class="fas fa-times"></i>

--- a/src/Fieldset/template/field/_validation.html
+++ b/src/Fieldset/template/field/_validation.html
@@ -11,7 +11,7 @@
                         {{> options_validation}}
                     </select>
                     <span class="input-group-btn">
-                        <a class="btn btn-danger" href="javascript:void(0)">
+                        <a class="btn btn-danger remove" href="javascript:void(0)">
                             <i class="fas fa-times"></i>
                         </a>
                     </span>

--- a/src/Model/controller.php
+++ b/src/Model/controller.php
@@ -789,7 +789,7 @@ $this->post('/admin/system/model/:schema/create', function ($request, $response)
             && trim($field['default'])
             // and there's no stage
             && $request->hasStage($name)
-            && !$request->getStage($name)
+            && $request->getStage($name) === ''
         ) {
             if (strtoupper($field['default']) === 'NOW()') {
                 $field['default'] = date('Y-m-d H:i:s');

--- a/src/Model/template/format/field.html
+++ b/src/Model/template/format/field.html
@@ -380,6 +380,7 @@
         {{#each config.attributes}}
             {{@key}}="{{this}}"
         {{/each}}
+        data-value="{{this}}"
     >
         {{#each config.options}}
             <option


### PR DESCRIPTION
 - Now Fieldsets can have the same name as schema names. When creating a fieldset field from a schema form, it will prefer to use the fieldset first, then the schema when there is a naming conflict.
 - Select field now stores the value in data-value for js driven select
 - Fix for removing validation rows in fieldset form
 - Fix for submitting fields with a zero value not saving to the database
